### PR TITLE
Add Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: c
+sudo: false
+dist: trusty
+
+addons:
+  apt:
+    packages:
+    - xorg-dev
+
+matrix:
+  include:
+  - compiler: clang
+    env: USER_FLAGS=-Werror
+
+  - compiler: gcc
+
+install: ./install-deps.sh
+
+script: make debug CC=$CC USER_FLAGS=$USER_FLAGS

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+[![Build Status](https://travis-ci.org/fmdkdd/megado.svg?branch=master)](https://travis-ci.org/fmdkdd/megado)
+
+Work in progress.
+
+## Build
+
+### Linux
+
+```
+git clone git@github.com:merwaaan/megado.git
+git submodule update --init --recursive
+./install-deps.sh
+make
+```
+
+`install-deps.sh` builds the dependencies in their own folder, and does not
+install anything into `/usr`.
+
+The `./run.sh` script builds and runs the emulator adding the dependencies on
+`LD_LIBRARY_PATH` if the build succeeds:
+
+```
+./run.sh release ROM
+```
+
+### Windows
+
+Use the MSVC solution `megado.sln`.

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # GLFW
 pushd deps/glfw/
@@ -27,7 +27,8 @@ popd
 
 # json-c
 pushd deps/json-c
-./configure --prefix=$(PWD)
+sh autogen.sh
+./configure --prefix=$PWD
 make
 make install
 popd

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# GLFW
+pushd deps/glfw/
+mkdir build
+pushd build
+cmake -DBUILD_SHARED_LIBS=ON ../
+make
+popd
+popd
+
+# GLEW
+pushd deps/glew/
+pushd auto
+make
+popd
+pushd build
+cmake ./cmake
+make
+popd
+popd
+
+# cimgui
+pushd deps/cimgui/cimgui
+make
+popd
+
+# json-c
+pushd deps/json-c
+./configure --prefix=$(PWD)
+make
+make install
+popd

--- a/megado/m68k/conditions.c
+++ b/megado/m68k/conditions.c
@@ -72,17 +72,17 @@ bool GreaterOrEqual(M68k* context)
 
 bool LessThan(M68k* context)
 {
-    return (NEGATIVE(context) & !OVERFLOW(context)) | (!NEGATIVE(context) & OVERFLOW(context));
+    return (NEGATIVE(context) & !OVERFLOW(context)) | ((!NEGATIVE(context)) & OVERFLOW(context));
 }
 
 bool GreaterThan(M68k* context)
 {
-    return (NEGATIVE(context) & OVERFLOW(context) & !ZERO(context)) | (!NEGATIVE(context) & !OVERFLOW(context) & !ZERO(context));
+    return (NEGATIVE(context) & OVERFLOW(context) & !ZERO(context)) | ((!NEGATIVE(context)) & !OVERFLOW(context) & !ZERO(context));
 }
 
 bool LessOrEqual(M68k* context)
 {
-    return ZERO(context) | (NEGATIVE(context) & !OVERFLOW(context)) | (!NEGATIVE(context) & OVERFLOW(context));
+    return ZERO(context) | (NEGATIVE(context) & !OVERFLOW(context)) | ((!NEGATIVE(context)) & OVERFLOW(context));
 }
 
 static Condition all_conditions[] = {

--- a/megado/m68k/instructions_transfer.c
+++ b/megado/m68k/instructions_transfer.c
@@ -41,7 +41,6 @@ Instruction* gen_exg(uint16_t opcode)
     default:
         fprintf(stderr, "Invalid mode %x in gen_exg\n", mode);
         exit(1);
-        // TODO error
         break;
     }
 

--- a/megado/m68k/instructions_transfer.c
+++ b/megado/m68k/instructions_transfer.c
@@ -121,8 +121,8 @@ Instruction* gen_move(uint16_t opcode)
 }
 
 // Computer pointers to the nth register in post-inc or pre-dec order
-#define MOVEM_POSTINC_ORDER(n) (n < 8 ? ctx->data_registers + n : ctx->address_registers + (n - 8))
-#define MOVEM_PREDEC_ORDER(n) (n < 8 ? ctx->address_registers + (7 - n) : ctx->data_registers + (7 - (n - 8)))
+#define MOVEM_POSTINC_ORDER(n) (n < 8 ? (uint32_t*)ctx->data_registers + n : ctx->address_registers + (n - 8))
+#define MOVEM_PREDEC_ORDER(n) (n < 8 ? ctx->address_registers + (7 - n) : (uint32_t*)ctx->data_registers + (7 - (n - 8)))
 
 uint8_t movem(Instruction* i, M68k* ctx)
 {
@@ -167,7 +167,7 @@ uint8_t movem(Instruction* i, M68k* ctx)
         }
 
     // Update the address register in pre-dec/post-inc modes
-    // (take into account the one dec/inc that is handled by the operand's pre/post functions) 
+    // (take into account the one dec/inc that is handled by the operand's pre/post functions)
     if (ea->type == AddressRegisterIndirectPreDec)
         ctx->address_registers[ea->n] = offset + size_in_bytes(i->size);
     else if (ea->type == AddressRegisterIndirectPostInc)
@@ -293,6 +293,6 @@ Instruction* gen_unlk(uint16_t opcode)
     Instruction* i = instruction_make("UNLK", unlk);
     i->size = Long;
     i->src = operand_make_address_register(FRAGMENT(opcode, 2, 0), i);
-    i->base_cycles = 12; 
+    i->base_cycles = 12;
     return i;
 }


### PR DESCRIPTION
Travis builds on Clang and GCC using our Makefile, including the dependencies.

I've turned on `-Werror` to fail the build on Clang if there are any warnings.  GCC has more warnings I haven't dealt with right now, so `-Werror` is turned off there.

I made a PR since I can't activate Travis myself, only the owner of the repo can by logging to Travis and turning on CI for the repo (hence why I used a fork).
